### PR TITLE
Catkinize the soem_robotiq_drivers package.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,11 +40,11 @@ include_directories(${soem_INCLUDE_DIRS})
 
 orocos_use_package(soem_master)
 
-orocos_plugin(soem_Robotiq src/soem_robotiq_drivers.cpp src/soem_robotiq_3Finger.cpp)
+orocos_plugin(soem_robotiq src/soem_robotiq_drivers.cpp src/soem_robotiq_3Finger.cpp)
 
-target_link_libraries(soem_Robotiq ${soem_LIBRARIES})
+target_link_libraries(soem_robotiq ${soem_LIBRARIES})
 
 if(NOT ORO_USE_ROSBUILD)
-  add_dependencies(soem_Robotiq ${PROJECT_NAME}_generate_messages_cpp)
+  add_dependencies(soem_robotiq ${PROJECT_NAME}_generate_messages_cpp)
 endif()
 orocos_generate_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,30 +11,40 @@ project(soem_robotiq_drivers)
 
  
 # Do setup in case of ros package, If ROS_ROOT is set, it is                                                                                                 # recommended to use RTT/OCL through the ros packages.                                                                                                       
-set (ROS_ROOT $ENV{ROS_ROOT} )
-if (ROS_ROOT)
-  include($ENV{ROS_ROOT}/core/rosbuild/rosbuild.cmake)
-  rosbuild_init()
-  rosbuild_find_ros_package( rtt )
-  set( RTT_HINTS HINTS ${rtt_PACKAGE_PATH}/../install )
-endif()
-
 #uncomment if you have defined messages
-rosbuild_genmsg()
+if(NOT ORO_USE_ROSBUILD)
+  find_package(catkin REQUIRED message_generation rtt_roscomm)
+  add_message_files( FILES
+    FingerMsg.msg
+    RobotiqMsg.msg
+    )
 
+  generate_messages()
+endif()
 # Set the CMAKE_PREFIX_PATH in case you're not using Orocos through
 # ROS for helping these find commands find RTT.
 find_package(OROCOS-RTT REQUIRED ${RTT_HINTS} )
-
 # Defines the orocos_* cmake macros. See that file for additional
 # documentation.
 include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
 
-rosbuild_include(rtt_rosnode GenerateRTTtypekit)
+if(ORO_USE_ROSBUILD)
+  rosbuild_genmsg()
+  rosbuild_include(rtt_rosnode GenerateRTTtypekit)
+endif()
 
 ros_generate_rtt_typekit(soem_robotiq_drivers)
 
+find_package(soem REQUIRED)
+include_directories(${soem_INCLUDE_DIRS})
+
+orocos_use_package(soem_master)
+
 orocos_plugin(soem_Robotiq src/soem_robotiq_drivers.cpp src/soem_robotiq_3Finger.cpp)
 
+target_link_libraries(soem_Robotiq ${soem_LIBRARIES})
 
-
+if(NOT ORO_USE_ROSBUILD)
+  add_dependencies(soem_Robotiq ${PROJECT_NAME}_generate_messages_cpp)
+endif()
+orocos_generate_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,13 @@ project(soem_robotiq_drivers)
 #  MinSizeRel     : w/o debug symbols, w/ optimization, stripped binaries
 #set(ROS_BUILD_TYPE RelWithDebInfo)
 
- 
+# Set the CMAKE_PREFIX_PATH in case you're not using Orocos through
+# ROS for helping these find commands find RTT.
+find_package(OROCOS-RTT REQUIRED ${RTT_HINTS} )
+# Defines the orocos_* cmake macros. See that file for additional
+# documentation.
+include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
+
 # Do setup in case of ros package, If ROS_ROOT is set, it is                                                                                                 # recommended to use RTT/OCL through the ros packages.                                                                                                       
 #uncomment if you have defined messages
 if(NOT ORO_USE_ROSBUILD)
@@ -21,12 +27,6 @@ if(NOT ORO_USE_ROSBUILD)
 
   generate_messages()
 endif()
-# Set the CMAKE_PREFIX_PATH in case you're not using Orocos through
-# ROS for helping these find commands find RTT.
-find_package(OROCOS-RTT REQUIRED ${RTT_HINTS} )
-# Defines the orocos_* cmake macros. See that file for additional
-# documentation.
-include(${OROCOS-RTT_USE_FILE_PATH}/UseOROCOS-RTT.cmake)
 
 if(ORO_USE_ROSBUILD)
   rosbuild_genmsg()

--- a/Makefile
+++ b/Makefile
@@ -1,1 +1,2 @@
+EXTRA_CMAKE_FLAGS += -DORO_USE_ROSBUILD=True
 include $(shell rospack find mk)/cmake.mk

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,0 +1,13 @@
+<package>
+    <description brief="Orocos soem_robotiq_drivers Component package">
+        This package contains the components of the rtt_soem_robotiq package
+    </description>
+    <!--NOTE: set the license and author before you publish this code-->
+    <license>LGPL</license>
+    <author>Wilson Ko</author>
+    <depend package="soem_core"/>
+    <depend package="soem_master"/>
+    <depend package="rtt"/>
+    <depend package="rtt_rosnode"/>
+</package>
+

--- a/manifest.xml
+++ b/manifest.xml
@@ -4,7 +4,7 @@
     </description>
     <!--NOTE: set the license and author before you publish this code-->
     <license>LGPL</license>
-    <author></author>
+    <author>Bert Willaert</author>
     <maintainer email="ruben@intermodalics.eu">Ruben Smits</maintainer>
     <depend package="soem_core"/>
     <depend package="soem_master"/>

--- a/manifest.xml
+++ b/manifest.xml
@@ -4,7 +4,8 @@
     </description>
     <!--NOTE: set the license and author before you publish this code-->
     <license>LGPL</license>
-    <author>Wilson Ko</author>
+    <author></author>
+    <maintainer email="ruben@intermodalics.eu">Ruben Smits</maintainer>
     <depend package="soem_core"/>
     <depend package="soem_master"/>
     <depend package="rtt"/>

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,7 @@
   <url type="website">http://wiki.ros.org/soem_master</url>
   <!-- <url type="bugtracker"></url> -->
 
-  <author></author>
+  <author>Bert Willaert</author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,7 @@
   <url type="website">http://wiki.ros.org/soem_master</url>
   <!-- <url type="bugtracker"></url> -->
 
-  <author>Ruben Smits</author>
+  <author></author>
 
   <buildtool_depend>catkin</buildtool_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,31 @@
+<package>
+  <name>soem_robotiq_drivers</name>
+  <version>0.1.1</version>
+  <description>
+      This package contains the components of the soem_robotiq_drivers package
+  </description>
+
+  <maintainer email="ruben@intermodalics.eu"> Ruben Smits</maintainer>
+
+  <license>LGPL</license>
+
+  <url type="website">http://wiki.ros.org/soem_master</url>
+  <!-- <url type="bugtracker"></url> -->
+
+  <author>Ruben Smits</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>rtt</build_depend>
+  <build_depend>soem</build_depend>
+  <build_depend>soem_master</build_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>rtt_roscomm</build_depend>
+
+  <run_depend>rtt</run_depend>
+  <run_depend>soem</run_depend>
+  <run_depend>soem_master</run_depend>
+  <run_depend>message_runtime</run_depend>
+  <run_depend>rtt_roscomm</run_depend>
+
+</package>

--- a/test_robotiq.ops
+++ b/test_robotiq.ops
@@ -1,9 +1,11 @@
 import("soem_beckhoff_drivers")
 import("soem_robotiq_drivers")
-import("rtt_rosnode") // makes this process a ROS node
+import("soem_master")
+import("rtt_rosnode")
+import("rtt_roscomm")
 
 loadComponent("Master","soem_master::SoemMasterComponent")
-Master.ifname = "eth1" 
+Master.ifname = "enp9s0"
 
 Master.setPeriod(0.001)
 Master.configure()
@@ -12,7 +14,4 @@ Master.displayAvailableDrivers()
 stream("Master.Slave_1001.Status",ros.topic("/status"))
 
 Master.Slave_1001.SetFingerVel (0.5)
-
 Master.Slave_1001.SetSinus(0.3,0.2)
-
-

--- a/test_robotiq.ops
+++ b/test_robotiq.ops
@@ -5,7 +5,7 @@ import("rtt_rosnode")
 import("rtt_roscomm")
 
 loadComponent("Master","soem_master::SoemMasterComponent")
-Master.ifname = "enp9s0"
+Master.ifname = "eth0"
 
 Master.setPeriod(0.001)
 Master.configure()


### PR DESCRIPTION
Makes the soem_robotiq_driver package compatible with catkin. Note: rather than rtt_soem_robotiq, the folder should be called soem_robotiq_drivers and should be placed in the rtt_soem stack, next to the soem_beckhoff_drivers.
